### PR TITLE
Fix/22 connect constants through hierarchical boundaries

### DIFF
--- a/fentwums-netlist-reader-helpers/src/main/java/de/thkoeln/fentwums/netlist/backend/helpers/ElkElementCreator.java
+++ b/fentwums-netlist-reader-helpers/src/main/java/de/thkoeln/fentwums/netlist/backend/helpers/ElkElementCreator.java
@@ -41,6 +41,7 @@ public class ElkElementCreator {
         newNode.setProperty(CoreOptions.SPACING_LABEL_NODE, 3.0d);
         newNode.setProperty(CoreOptions.SPACING_EDGE_EDGE, 10.0d);
         newNode.setProperty(CoreOptions.RANDOM_SEED, 1);
+        newNode.setProperty(CoreOptions.HIERARCHY_HANDLING, HierarchyHandling.INCLUDE_CHILDREN);
 
         return newNode;
     }

--- a/fentwums-netlist-reader-hierarchical/src/main/java/de/thkoeln/fentwums/netlist/backend/hierarchical/parser/PortHandler.java
+++ b/fentwums-netlist-reader-hierarchical/src/main/java/de/thkoeln/fentwums/netlist/backend/hierarchical/parser/PortHandler.java
@@ -205,6 +205,10 @@ public class PortHandler {
                     }
                 }
 
+                if (!reversedPort) {
+                    constantValues.reverse();
+                }
+
                 // Also generate the driver node
                 if (createdPortSide == PortSide.EAST) {
                     // Const outputs are generated as a child


### PR DESCRIPTION
Fixes #22 

<img width="1799" height="63" alt="image" src="https://github.com/user-attachments/assets/8c555ca4-38b8-4083-9c17-23316f0022a7" />

Constant values are now connected through hierarchical boundaries, even multiple, if so specified by the netlist