### PR TITLE
Add support for several new customization options

### DIFF
--- a/fentwums-netlist-reader-datatypes/src/main/java/de/thkoeln/fentwums/netlist/backend/datatypes/NetlistCreationSettings.java
+++ b/fentwums-netlist-reader-datatypes/src/main/java/de/thkoeln/fentwums/netlist/backend/datatypes/NetlistCreationSettings.java
@@ -9,6 +9,9 @@ public class NetlistCreationSettings {
 	private double edgeLabelFontSize;
 	private PerformanceTarget performanceTarget;
 	private RequestedJunctionShape junctionShape;
+	private int layoutEffort;
+	private boolean showUnconnectedPorts;
+	private boolean onlyShowUserCreatedSignalNames;
 
 	/**
 	 * Creates a new settings store for the associated netlist
@@ -18,13 +21,16 @@ public class NetlistCreationSettings {
 	 * @param portLabelFontSize	Fontsize for ports
 	 * @param edgeLabelFontSize	Fontsize for edges
 	 */
-	public NetlistCreationSettings(double entityLabelFontSize, double cellLabelFontSize, double portLabelFontSize, double edgeLabelFontSize, PerformanceTarget performanceTarget, RequestedJunctionShape junctionShape) {
+	public NetlistCreationSettings(double entityLabelFontSize, double cellLabelFontSize, double portLabelFontSize, double edgeLabelFontSize, PerformanceTarget performanceTarget, RequestedJunctionShape junctionShape, int layoutEffort, boolean showUnconnectedPorts, boolean onlyShowUserCreatedSignalNames) {
 		this.entityLabelFontSize = entityLabelFontSize;
 		this.cellLabelFontSize = cellLabelFontSize;
 		this.portLabelFontSize = portLabelFontSize;
 		this.edgeLabelFontSize = edgeLabelFontSize;
 		this.performanceTarget = performanceTarget;
 		this.junctionShape = junctionShape;
+		this.layoutEffort = layoutEffort;
+		this.showUnconnectedPorts = showUnconnectedPorts;
+		this.onlyShowUserCreatedSignalNames = onlyShowUserCreatedSignalNames;
 	}
 
 	/**
@@ -74,5 +80,17 @@ public class NetlistCreationSettings {
 
 	public RequestedJunctionShape getJunctionShape() {
 		return junctionShape;
+	}
+
+	public int getLayoutEffort() {
+		return layoutEffort;
+	}
+
+	public boolean doShowUnconnectedPorts() {
+		return showUnconnectedPorts;
+	}
+
+	public boolean doOnlyShowUserCreatedSignalNames() {
+		return onlyShowUserCreatedSignalNames;
 	}
 }

--- a/fentwums-netlist-reader-helpers/src/main/java/de/thkoeln/fentwums/netlist/backend/helpers/EdgeBundler.java
+++ b/fentwums-netlist-reader-helpers/src/main/java/de/thkoeln/fentwums/netlist/backend/helpers/EdgeBundler.java
@@ -403,7 +403,11 @@ public class EdgeBundler {
 					// Remove existing label
 					reworkPort.getLabels().clear();
 
-					reworkPort.setProperty(FEntwumSOptions.NOT_CONNECTED, true);
+					if (settings.doShowUnconnectedPorts()) {
+						reworkPort.setProperty(FEntwumSOptions.NOT_CONNECTED, true);
+					} else {
+						continue;
+					}
 
 					// Create new label
 					ElkLabel newConstLabel = ElkElementCreator

--- a/fentwums-netlist-reader-helpers/src/main/java/de/thkoeln/fentwums/netlist/backend/helpers/EdgeBundler.java
+++ b/fentwums-netlist-reader-helpers/src/main/java/de/thkoeln/fentwums/netlist/backend/helpers/EdgeBundler.java
@@ -259,7 +259,7 @@ public class EdgeBundler {
 
 				if (currentPort.getProperty(CoreOptions.PORT_SIDE).equals(PortSide.EAST)) {
 					if (bundleList.size() > 1) {
-						List<String> strl = createLabelsFromBundles(bundleList, fullsizeBundles, false);
+						List<String> strl = createLabelsFromBundles(bundleList, fullsizeBundles, false, settings);
 
 						SignalSplit split = ElkElementCreator.createSignalSplit(entityInstance, currentPort,
 								strl, settings);
@@ -306,7 +306,7 @@ public class EdgeBundler {
 									.log();
 						}
 
-						List<String> strl = createLabelsFromBundles(bundleList, new ArrayList<BundleRange>(), true);
+						List<String> strl = createLabelsFromBundles(bundleList, new ArrayList<BundleRange>(), true, settings);
 
 						SignalAgg agg = ElkElementCreator.createSignalAgg(entityInstance, currentPort,
 								strl, settings);
@@ -568,7 +568,7 @@ public class EdgeBundler {
 
 			if (crossingPort.getProperty(CoreOptions.PORT_SIDE).equals(comparisonPortSide)) {
 				// Instance input -> split
-				List<String> strl = createLabelsFromBundles(bundleList, new ArrayList<>(), false);
+				List<String> strl = createLabelsFromBundles(bundleList, new ArrayList<>(), false, settings);
 
 				SignalSplit split = ElkElementCreator.createSignalSplit(aggSplitContainingNode, crossingPort, strl, settings);
 
@@ -589,7 +589,7 @@ public class EdgeBundler {
 				}
 			} else {
 				// Instance output -> agg
-				List<String> strl = createLabelsFromBundles(bundleList, new ArrayList<>(), true);
+				List<String> strl = createLabelsFromBundles(bundleList, new ArrayList<>(), true, settings);
 
 				SignalAgg agg = ElkElementCreator.createSignalAgg(aggSplitContainingNode, crossingPort, strl, settings);
 
@@ -752,23 +752,19 @@ public class EdgeBundler {
 		return sigBitList;
 	}
 
-	private static List<String> createLabelsFromBundles(List<BundleRange> bundleList, List<BundleRange> excludedBundles, boolean forAgg) {
+	private static List<String> createLabelsFromBundles(List<BundleRange> bundleList, List<BundleRange> excludedBundles, boolean forAgg, NetlistCreationSettings settings) {
 		List<String> strl = bundleList.stream().filter(b -> !excludedBundles.contains(b)).map(b -> {
 			String ret = "";
 
-			//List<String> a =
-
-			String sharedNameAcrossBundles = findSharedNetNameAcrossBundles(bundleList, forAgg);
+			NetAssociation sharedNetAssociationAcrossBundles = findSharedNetNameAcrossBundles(bundleList, forAgg);
+			String sharedNameAcrossBundles = sharedNetAssociationAcrossBundles == null ? "" : sharedNetAssociationAcrossBundles.netName();
 			String sharedOriginName = "";
+			NetAssociation sharedOriginAssociation = null;
 			List<Range> sharedOriginBitRanges = new ArrayList<>();
 			ElkPort sharedOriginPort = null;
 
 			if (forAgg) {
 				List<NetAssociation> sharedNamesInBundle = findSharedNetNameInBundle(b);
-
-				if (sharedNamesInBundle.stream().anyMatch(a -> a.netName().equals("dat_xnor_s"))) {
-					int i = 0;
-				}
 
 				List<NetAssociation> sharedUserGeneratedNamesInBundle = sharedNamesInBundle.stream().filter(a -> a.validityLevel().equals(SignalNameValidityLevel.USER_CREATED)).toList();
 
@@ -798,18 +794,22 @@ public class EdgeBundler {
 
 						if (sharedOriginName.isEmpty()) {
 							if (!nonPortSharedNamesInBundle.isEmpty()) {
-								sharedOriginName = nonPortSharedNamesInBundle.getFirst().netName();
+								sharedOriginAssociation = nonPortSharedNamesInBundle.getFirst();
+								sharedOriginName = sharedOriginAssociation.netName();
 							} else {
-								sharedOriginName = sharedUserGeneratedNamesInBundle.getFirst().netName();
+								sharedOriginAssociation = sharedUserGeneratedNamesInBundle.getFirst();
+								sharedOriginName = sharedOriginAssociation.netName();
 							}
 						}
 					} else {
-						sharedOriginName = sharedUserGeneratedNamesInBundle.getFirst().netName();
+						sharedOriginAssociation = sharedUserGeneratedNamesInBundle.getFirst();
+						sharedOriginName = sharedOriginAssociation.netName();
 					}
 				}
 
 				if (sharedOriginName.isEmpty() && !sharedNamesInBundle.isEmpty()) {
-					sharedOriginName = sharedNamesInBundle.getFirst().netName();
+					sharedOriginAssociation =  sharedNamesInBundle.getFirst();
+					sharedOriginName = sharedOriginAssociation.netName();
 				}
 			}
 
@@ -855,7 +855,10 @@ public class EdgeBundler {
 					logger.warn("Found split origin range for single bundle");
 				}
 
-				ret += sharedOriginName;
+				if (!(settings.doOnlyShowUserCreatedSignalNames() && sharedOriginAssociation != null && !sharedOriginAssociation.validityLevel().equals(SignalNameValidityLevel.USER_CREATED)))
+				{
+					ret += sharedOriginName;
+				}
 				if (!sharedOriginBitRanges.isEmpty()) {
 					sharedOriginBitRanges.sort(Range::compareTo);
 					sharedOriginBitRanges = sharedOriginBitRanges.reversed();
@@ -876,7 +879,9 @@ public class EdgeBundler {
 						ret += ']';
 					}
 
-					ret += " ⮞ ";
+					if (!ret.isEmpty()) {
+						ret += " ⮞ ";
+					}
 				}
 			}
 
@@ -886,7 +891,9 @@ public class EdgeBundler {
 					ret += b.associatedEdges().getFirst().getProperty(FEntwumSOptions.SIGNAL_NAME);
 				}
 			} else {
-				ret += sharedNameAcrossBundles;
+				if (!(settings.doOnlyShowUserCreatedSignalNames() && sharedNetAssociationAcrossBundles != null && !sharedNetAssociationAcrossBundles.validityLevel().equals(SignalNameValidityLevel.USER_CREATED))) {
+					ret += sharedNameAcrossBundles;
+				}
 			}
 			ret += "[";
 
@@ -995,12 +1002,12 @@ public class EdgeBundler {
 		}
 	}
 
-	private static String findSharedNetNameAcrossBundles(List<BundleRange> bundleList, boolean forAgg) {
+	private static NetAssociation findSharedNetNameAcrossBundles(List<BundleRange> bundleList, boolean forAgg) {
 		List<List<NetAssociation>> candidates = bundleList.stream().filter(b -> !(b.associatedEdges().getFirst().getProperty(FEntwumSOptions.SIGNAL_TYPE).equals(SignalType.CONSTANT)
 						|| b.associatedEdges().getFirst().getProperty(FEntwumSOptions.SIGNAL_TYPE).equals(SignalType.BUNDLED_CONSTANT))).map(EdgeBundler::findSharedNetNameInBundle).toList();
 
 		if (candidates.isEmpty()) {
-			return "";
+			return null;
 		}
 
 		List<NetAssociation> choices = new ArrayList<>();
@@ -1010,7 +1017,7 @@ public class EdgeBundler {
 		}
 
 		if (choices.size() == 1) {
-			return choices.getFirst().netName();
+			return choices.getFirst();
 		}
 
 		List<NetAssociation> results = choices.stream().filter(c -> candidates.stream().allMatch(comp -> comp.stream().anyMatch(m -> m.netName().equals(c.netName())))).toList();
@@ -1030,7 +1037,7 @@ public class EdgeBundler {
 		}
 
 		if (results.isEmpty()) {
-			return "";
+			return null;
 		} else {
 			NetAssociation bestMatch = results.getFirst();
 			int lowestBit = Integer.MAX_VALUE;
@@ -1119,7 +1126,7 @@ public class EdgeBundler {
 				}
 			}
 
-			return bestMatch.netName();
+			return bestMatch;
 		}
 	}
 

--- a/fentwums-netlist-reader-helpers/src/main/java/de/thkoeln/fentwums/netlist/backend/helpers/ElkElementCreator.java
+++ b/fentwums-netlist-reader-helpers/src/main/java/de/thkoeln/fentwums/netlist/backend/helpers/ElkElementCreator.java
@@ -30,7 +30,7 @@ public class ElkElementCreator {
 	 * @param identifier The identifier of the node to be created
 	 * @return The created child node
 	 */
-	public static ElkNode createNewNode(ElkNode parent, String identifier) {
+	public static ElkNode createNewNode(ElkNode parent, String identifier, NetlistCreationSettings settings) {
 		ElkNode newNode = createNode(parent);
 		newNode.setIdentifier(identifier);
 		newNode.setProperty(CoreOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_ORDER);
@@ -47,6 +47,7 @@ public class ElkElementCreator {
 		newNode.setProperty(CoreOptions.RANDOM_SEED, 1);
 		newNode.setProperty(CoreOptions.HIERARCHY_HANDLING, HierarchyHandling.INCLUDE_CHILDREN);
 		newNode.setProperty(LayeredOptions.NODE_PLACEMENT_BK_FIXED_ALIGNMENT, FixedAlignment.BALANCED);
+		newNode.setProperty(LayeredOptions.THOROUGHNESS, settings.getLayoutEffort());
 
 		return newNode;
 	}

--- a/fentwums-netlist-reader-helpers/src/main/java/de/thkoeln/fentwums/netlist/backend/helpers/PortMarker.java
+++ b/fentwums-netlist-reader-helpers/src/main/java/de/thkoeln/fentwums/netlist/backend/helpers/PortMarker.java
@@ -1,27 +1,34 @@
 package de.thkoeln.fentwums.netlist.backend.helpers;
 
+import de.thkoeln.fentwums.netlist.backend.datatypes.NetlistCreationSettings;
 import de.thkoeln.fentwums.netlist.backend.elkoptions.FEntwumSOptions;
 import org.eclipse.elk.graph.ElkNode;
 import org.eclipse.elk.graph.ElkPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+
 public class PortMarker {
 	private static Logger logger = LoggerFactory.getLogger(PortMarker.class);
 
-	public void mark(ElkNode graph) {
-		for (ElkPort port : graph.getPorts()) {
-			markPort(port);
+	public void mark(ElkNode graph, NetlistCreationSettings settings) {
+		for (ElkPort port : new ArrayList<ElkPort>(graph.getPorts())) {
+			markPort(port, settings);
 		}
 
 		for (ElkNode node : graph.getChildren()) {
-			mark(node);
+			mark(node, settings);
 		}
 	}
 
-	private void markPort(ElkPort port) {
+	private void markPort(ElkPort port, NetlistCreationSettings settings) {
 		if (port.getOutgoingEdges().isEmpty() && port.getIncomingEdges().isEmpty()) {
-			port.setProperty(FEntwumSOptions.NOT_CONNECTED, true);
+			if (settings.doShowUnconnectedPorts()) {
+				port.setProperty(FEntwumSOptions.NOT_CONNECTED, true);
+			} else {
+				port.getParent().getPorts().remove(port);
+			}
 		}
 	}
 }

--- a/fentwums-netlist-reader-hierarchical/src/main/java/de/thkoeln/fentwums/netlist/backend/hierarchical/parser/CellHandler.java
+++ b/fentwums-netlist-reader-hierarchical/src/main/java/de/thkoeln/fentwums/netlist/backend/hierarchical/parser/CellHandler.java
@@ -111,7 +111,7 @@ public class CellHandler {
                 isDerived = true;
             }
 
-            ElkNode newCellNode = ElkElementCreator.createNewNode(parentNode, cellName);
+            ElkNode newCellNode = ElkElementCreator.createNewNode(parentNode, cellName, settings);
             newCellNode.setProperty(FEntwumSOptions.CELL_NAME, cellName);
 
             newCellNode.setProperty(FEntwumSOptions.SRC_LOCATION, srcLocation);

--- a/fentwums-netlist-reader-hierarchical/src/main/java/de/thkoeln/fentwums/netlist/backend/hierarchical/parser/HierarchicalOrchestrator.java
+++ b/fentwums-netlist-reader-hierarchical/src/main/java/de/thkoeln/fentwums/netlist/backend/hierarchical/parser/HierarchicalOrchestrator.java
@@ -46,6 +46,7 @@ public class HierarchicalOrchestrator implements IGraphCreator {
         root.setProperty(CoreOptions.HIERARCHY_HANDLING, HierarchyHandling.INCLUDE_CHILDREN);
         root.setProperty(CoreOptions.NODE_SIZE_CONSTRAINTS, EnumSet.allOf(SizeConstraint.class));
         root.setProperty(CoreOptions.PARTITIONING_ACTIVATE, true);
+        root.setProperty(LayeredOptions.THOROUGHNESS, settings.getLayoutEffort());
         root.setIdentifier("root");
 
         HashMap<String, Object> modules = (HashMap<String, Object>) netlist.get("modules");
@@ -68,7 +69,7 @@ public class HierarchicalOrchestrator implements IGraphCreator {
             return null;
         }
 
-        ElkNode topNode = ElkElementCreator.createNewNode(root, topName);
+        ElkNode topNode = ElkElementCreator.createNewNode(root, topName, settings);
         topNode.setProperty(FEntwumSOptions.CELL_TYPE, "HDL_ENTITY");
         topNode.setProperty(CoreOptions.INSIDE_SELF_LOOPS_ACTIVATE, true);
 

--- a/fentwums-netlist-reader-server/src/main/java/de/thkoeln/fentwums/netlist/backend/netlistreaderbackendspringboot/NetlistReaderBackendSpringBootApplication.java
+++ b/fentwums-netlist-reader-server/src/main/java/de/thkoeln/fentwums/netlist/backend/netlistreaderbackendspringboot/NetlistReaderBackendSpringBootApplication.java
@@ -124,7 +124,14 @@ public class NetlistReaderBackendSpringBootApplication {
                                                                    String performanceTarget,
                                                                    @RequestParam(value = "test-mode", defaultValue =
                                                                            "0") String testMode,
-                                                                   @RequestParam(value = "junctionShape", defaultValue = "CIRCLE") String junctionShape) {
+                                                                   @RequestParam(value = "junctionShape", defaultValue =
+                                                                           "CIRCLE") String junctionShape,
+                                                                   @RequestParam(value = "layoutEffort",
+                                                                           defaultValue = "7") int layoutEffort,
+                                                                   @RequestParam(value = "showUnconnectedPorts",
+                                                                           defaultValue = "false") boolean showUnconnectedPorts,
+                                                                   @RequestParam(value = "onlyShowUserGeneratedSignalNames",
+                                                                           defaultValue = "false") boolean onlyShowUserGeneratedSignalNames) {
         System.gc();
         System.gc();
 
@@ -153,7 +160,8 @@ public class NetlistReaderBackendSpringBootApplication {
 
         NetlistCreationSettings settings = new NetlistCreationSettings(entityLabelFontSize, cellLabelFontSize,
                                                                        edgeLabelFontSize, portLabelFontSize,
-                                                                       target, shape);
+                                                                       target, shape, layoutEffort, showUnconnectedPorts,
+                                                                       onlyShowUserGeneratedSignalNames);
         try {
             switch (NetlistDifferentiator.differentiate(file.getInputStream())) {
                 case HIERARCHICAL -> {

--- a/fentwums-netlist-reader-service/src/main/java/de/thkoeln/fentwums/netlist/backend/parser/CellHandler.java
+++ b/fentwums-netlist-reader-service/src/main/java/de/thkoeln/fentwums/netlist/backend/parser/CellHandler.java
@@ -103,7 +103,7 @@ public class CellHandler {
 						}
 
 						ElkNode newElkNode = ElkElementCreator.createNewNode(currentHierarchyPosition.getNode(),
-								intermediateCellPath.toString());
+								intermediateCellPath.toString(), settings);
 
 						newElkNode.setProperty(FEntwumSOptions.LOCATION_PATH, intermediateCellPath.toString());
 						newElkNode.setProperty(FEntwumSOptions.CELL_TYPE, "HDL_ENTITY");
@@ -132,7 +132,7 @@ public class CellHandler {
 
 			// now that the hierarchy has been created, the actual cells can be constructed
 
-			ElkNode newCellNode = ElkElementCreator.createNewNode(currentHierarchyPosition.getNode(), currentCellPath);
+			ElkNode newCellNode = ElkElementCreator.createNewNode(currentHierarchyPosition.getNode(), currentCellPath, settings);
 
 			newCellNode.setProperty(FEntwumSOptions.CELL_NAME, currentCellPathSplit[currentCellPathSplit.length - 1]);
 			newCellNode.setProperty(FEntwumSOptions.CELL_TYPE, celltype);

--- a/fentwums-netlist-reader-service/src/main/java/de/thkoeln/fentwums/netlist/backend/parser/GraphCreator.java
+++ b/fentwums-netlist-reader-service/src/main/java/de/thkoeln/fentwums/netlist/backend/parser/GraphCreator.java
@@ -162,7 +162,7 @@ public class GraphCreator implements IGraphCreator {
 
 		// Mark any ports that are not connected to any signal
 		PortMarker marker = new PortMarker();
-		marker.mark(toplevel);
+		marker.mark(toplevel, settings);
 
 		checker.checkGraph(root);
 


### PR DESCRIPTION
This PR allows setting the following new options at initial graph generation:
- Setting the maximum effort during graph layouting
- Removing unconnected ports on cells
- Only showing signal names present in the HDL sources